### PR TITLE
TroutSlap: Fix regex to be less greedy

### DIFF
--- a/lib/hedwig_simple_responders/responders/trout_slap.ex
+++ b/lib/hedwig_simple_responders/responders/trout_slap.ex
@@ -9,14 +9,17 @@ defmodule HedwigSimpleResponders.TroutSlap do
   """
 
   hear ~r/^slap me/i, message do
-    emote(message, "slaps #{message.user.name} around a bit with a large trout")
+    target = if is_map(message.user) do message.user.name else message.user end
+    send message, "slaps #{target} around a bit with a large trout"
   end
   hear ~r/^slaps me/i, _, do: :ok
-  hear ~r/^slaps?\s*(?<target>\w+).*/i, message do
-    emote(message, "slaps #{message.matches["target"]} around a bit with a large trout")
+  hear ~r/^slaps? (?<target>[^<\s]+)/i, message do
+    target = message.matches["target"]
+    if target == "me" do :ok else send message, "slaps #{target} around a bit with a large trout" end
   end
   # match slack mentions which come over as <@U0DM97L3T>
-  hear ~r/^slaps?\s*<@(?<target>\w+)>.*/i, message do
-    emote(message, "slaps <@#{message.matches["target"]}> around a bit with a large trout")
+  hear ~r/^slaps? <@(?<target>[^\s]+)>/i, message do
+    # send can reference users, emote/me_message cannot
+    send message, "slaps <@#{message.matches["target"]}> around a bit with a large trout"
   end
 end


### PR DESCRIPTION
Also prevent multiple slap responders from firing simultaneously e.g. "slaps me"